### PR TITLE
fix: SP画面でタイトルが見切れていたのでクラスを削除

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import { informationList } from "../definitions/commonDefinitions";
 
 export default function Home() {
 	return (
-		<div className="min-h-screen px-2 flex flex-col justify-center items-center h-screen">
+		<div className="min-h-screen px-2 flex flex-col justify-center items-center">
 			<Head>
 				<title>Takana Mayo App</title>
 				<meta name="description" content="Welcome to Takana Mayo app" />


### PR DESCRIPTION
Closes #16

## 概要
- SP画面でタイトルが見切れていた

## テストしたこと・確認したこと
- エミュレータでタイトルが見切れないことを確認
